### PR TITLE
Improving buzzwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PAT ERC20 Compatible Token
 
-The Pangea Software is a Decentralized Opt-In Jurisdiction where Citizens can conduct peer-to-peer arbitration and create their own Sovereign Nations. Pangea is built with the decentralized Secure Scuttlebot (SSB) and Interplanetary File System (IPFS) technologies, forming a quantum resistant mesh network. Pangea is blockchain agnostic, using primarily the Ethereum and Bitcoin blockchains.
+The Pangea Software is a Decentralized Opt-In Jurisdiction where Citizens can conduct peer-to-peer arbitration and create their own Sovereign Nations. Pangea is built with the decentralized Secure Scuttlebot (SSB) and Interplanetary File System (IPFS) technologies, forming a resistant overlay mesh network. Pangea is blockchain agnostic, using primarily the Ethereum and Bitcoin blockchains.
 
 The Pangea Arbitration Token (PAT) is an ERC20 Compatible in-app token for the Pangea Jurisdiction. The PAT token is proof-of-reputation for Citizens, issued when they create a contract, successfully complete a contract or resolve a dispute attached to a contract. Thus, PAT is an algorithmic reputation token; an arbitration currency based on performance, not based on purchasing power, popularity, or attention. 
 


### PR DESCRIPTION
Throwing out quantum part. I think it does not add anything to it and sounds more like pseudo science buzzword. I do not think this is realistic threat model, but you should really define better than what means this quantum part if you really want this.

Changed "mesh network" to "overlay mesh network" because here you are not building a physical network (like with wireless links). Or you could use "mesh network topology" instead as well.